### PR TITLE
add POST /api/articles/article_id/comments endpoint, tests and error …

### DIFF
--- a/__tests__/comments.test.js
+++ b/__tests__/comments.test.js
@@ -63,3 +63,109 @@ describe("GET /api/articles/:article_id/comments", () => {
       });
   });
 });
+
+describe("POST /api/articles/:article_id/comments", () => {
+  test("status 201: return the posted comment object, with the correct keys and values ", () => {
+    const article_id = 1;
+    const newComment = {
+      username: "butter_bridge",
+      body: "this is a test comment",
+    };
+
+    return request(app)
+      .post(`/api/articles/${article_id}/comments`)
+      .send(newComment)
+      .expect(201)
+      .then(({ body }) => {
+        expect(body.comment).toEqual({
+          article_id: article_id,
+          author: newComment.username,
+          body: newComment.body,
+          comment_id: 19,
+          votes: 0,
+          created_at: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[A-Z]$/
+          ),
+        });
+      });
+  });
+
+  test("status 400: invalid data (usename doesn't exist)", () => {
+    const article_id = 1;
+    const newComment = {
+      username: "liam_carswell",
+      body: "this username doesn't exist",
+    };
+
+    return request(app)
+      .post(`/api/articles/${article_id}/comments`)
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("Bad request, reference doesn't exist");
+      });
+  });
+
+  test("status 400: missing data (no comment body)", () => {
+    const article_id = 1;
+    const newComment = {
+      username: "butter_bridge",
+    };
+
+    return request(app)
+      .post(`/api/articles/${article_id}/comments`)
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("Bad request, missing data");
+      });
+  });
+
+  test("status 400: missing data (comment body is an empty string)", () => {
+    const article_id = 1;
+    const newComment = {
+      username: "butter_bridge",
+      body: "",
+    };
+
+    return request(app)
+      .post(`/api/articles/${article_id}/comments`)
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("Comment cannot be empty");
+      });
+  });
+
+  test("status 400: incorrect data format (article_id isn't a number)", () => {
+    const article_id = "one";
+    const newComment = {
+      username: "butter_bridge",
+      body: "this is a test comment",
+    };
+
+    return request(app)
+      .post(`/api/articles/${article_id}/comments`)
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("Bad request, invalid data");
+      });
+  });
+
+  test("status 400: invalid data (article_id doesn't exist)", () => {
+    const article_id = 9999;
+    const newComment = {
+      username: "butter_bridge",
+      body: "this is a test comment",
+    };
+
+    return request(app)
+      .post(`/api/articles/${article_id}/comments`)
+      .send(newComment)
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toEqual("Bad request, that article doesn't exist");
+      });
+  });
+});

--- a/app.js
+++ b/app.js
@@ -6,7 +6,10 @@ const {
   patchArticleVotes,
 } = require("./controllers/articles");
 const { getUsers } = require("./controllers/users");
-const { getArticleComments } = require("./controllers/comments");
+const {
+  getArticleComments,
+  postArticleComment,
+} = require("./controllers/comments");
 const {
   handleRouteNotFound,
   handlePsqlErrors,
@@ -30,6 +33,7 @@ app.get("/api/users", getUsers);
 
 // comments
 app.get("/api/articles/:article_id/comments", getArticleComments);
+app.post("/api/articles/:article_id/comments", postArticleComment);
 
 // error handling
 app.use("/*", handleRouteNotFound);

--- a/controllers/comments.js
+++ b/controllers/comments.js
@@ -1,4 +1,7 @@
-const { selectArticleComments } = require("../models/comments");
+const {
+  selectArticleComments,
+  addArticleComment,
+} = require("../models/comments");
 const { selectArticleById } = require("../models/articles");
 
 exports.getArticleComments = (req, res, next) => {
@@ -14,4 +17,23 @@ exports.getArticleComments = (req, res, next) => {
       res.status(200).send({ comments });
     })
     .catch(next);
+};
+
+exports.postArticleComment = (req, res, next) => {
+  const { article_id } = req.params;
+  const { username, body } = req.body;
+
+  const promises = [
+    selectArticleById(article_id),
+    addArticleComment(article_id, username, body),
+  ];
+
+  Promise.all(promises)
+    .then(([_, comment]) => {
+      res.status(201).send({ comment });
+    })
+    .catch((err) => {
+      console.log(err);
+      next(err);
+    });
 };

--- a/controllers/errors.js
+++ b/controllers/errors.js
@@ -8,6 +8,8 @@ exports.handlePsqlErrors = (err, req, res, next) => {
     res.status(400).send({ msg: "Bad request, invalid data" });
   } else if (err.code === "23502") {
     res.status(400).send({ msg: "Bad request, missing data" });
+  } else if (err.code === "23503") {
+    res.status(400).send({ msg: "Bad request, reference doesn't exist" });
   } else {
     next(err);
   }

--- a/models/comments.js
+++ b/models/comments.js
@@ -7,3 +7,17 @@ exports.selectArticleComments = (article_id) => {
 
   return db.query(queryText, queryVals).then((comments) => comments.rows);
 };
+
+exports.addArticleComment = (article_id, username, body) => {
+  if (body === "") {
+    return Promise.reject({ status: 400, msg: "Comment cannot be empty" });
+  }
+
+  const queryText = `INSERT INTO comments
+    (article_id, author, body)
+    VALUES ($1, $2, $3)
+    RETURNING *`;
+  const queryVals = [article_id, username, body];
+
+  return db.query(queryText, queryVals).then((comment) => comment.rows[0]);
+};


### PR DESCRIPTION
- added POST /api/articles/:article_id/comments endpoint
- added tests and error handing for response contents, invalid request body and invalid article_id

Note that where the instructions say "Respond with the posted comment", I've taken that to mean the posted comment object (including author, comment_id etc.) rather than just the posted comment body... Shout if I've misunderstood 